### PR TITLE
Graph not sorted by date fix

### DIFF
--- a/minecraft_logs_analyzer.pyw
+++ b/minecraft_logs_analyzer.pyw
@@ -321,6 +321,7 @@ def create_graph():
 			return
 		data_list_dates = [dates for dates in graph_data_collection]
 		data_list_hour = [hours[1] for hours in graph_data_collection.items()]
+		data_list_dates, data_list_hour = zip(*sorted(zip(data_list_dates, data_list_hour)))
 		plt.bar(data_list_dates, data_list_hour, color=graph_color)
 		
 		plt.xticks(rotation='vertical')


### PR DESCRIPTION
For some reason the dates on the graph weren't sorted, so i added a line to sort data_list_dates and data_list_hours.

before:
![Figure_1](https://user-images.githubusercontent.com/86300562/132983500-21703c6e-d31b-401b-99e5-6614d8074ccc.png)

after:
![sorted](https://user-images.githubusercontent.com/86300562/132985853-0a49f7a0-63c0-425d-b7a1-957b49195280.png)
