### PR TITLE
Fix for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ If that does not work try to reinstall python and make sure to click the install
 The program will also detect if you do not have matplotlib installed, and it will ask you if you want to auto install.
 This will basically run `os.system("pip install --user matplotlib")` this is the same as running `pip install --user matplotlib` in the cmd.
 
+## Running on linux
+Linux support seems to be WIP but you should just be able to run `python3 minecraft_logs_analyzer.pyw` and manually specify the minecraft logs path if you have to. Make sure to install the dependencies with pip `python3 -m pip install matplotlib`
+
 ## Authors:
 - Hawkpath (hawkpathas@gmail.com)
 - Quinten (tintin10q@hotmail.com)

--- a/minecraft_logs_analyzer.pyw
+++ b/minecraft_logs_analyzer.pyw
@@ -129,7 +129,7 @@ def iter_logs(path):
 			continue
 		elif not file.name.startswith('20'):
 			continue
-		with open_methods[file.suffix](file, 'rt', encoding='ansi', errors='replace', newline='') as f:
+		with open_methods[file.suffix](file, 'rt', encoding='utf-8', errors='replace', newline='') as f:
 			yield f
 
 
@@ -474,7 +474,7 @@ if __name__ == '__main__':
 	stopButton = Button(frame, text="Stop scanning", command=exit, width=20, bg=background_color, fg=fg_color, font="Helvetica 10")
 	stopButton.pack()
 	
-	if os.path.exists("icon.ico"):
+	if os.path.exists("icon.ico") and platform != "linux" and platform != "linux2":
 		root.iconbitmap("icon.ico")
 	else:
 		print("Could not find icon.ico so using default tkinter icon")


### PR DESCRIPTION
There were several errors keeping me from running the script on my Linux Mint 21 machine. I am not the most experienced in python but these fixes should allow it to run on linux without affecting anyone else's experience. Then again, it could just be my install that had these issues.

The icon didn't want to import
```py
Traceback (most recent call last):
  File ".../minecraft-logs-analyzer/minecraft_logs_analyzer.pyw", line 478, in <module>
    root.iconbitmap("icon.ico")
  File "/usr/lib/python3.10/tkinter/__init__.py", line 2109, in wm_iconbitmap
    return self.tk.call('wm', 'iconbitmap', self._w, bitmap)
_tkinter.TclError: bitmap "icon.ico" not defined
```
so I had it not use the icon on linux.

The second error happened when I ran it.
```py
Traceback (most recent call last):
  File ".../minecraft-logs-analyzer/minecraft_logs_analyzer.pyw", line 263, in count_playtimes_tread
    total_time += count_playtime(path, print_files='full' if len(paths) > 1 else 'file')
  File ".../minecraft-logs-analyzer/minecraft_logs_analyzer.pyw", line 144, in count_playtime
    for log in iter_logs(path):
  File ".../minecraft-logs-analyzer/minecraft_logs_analyzer.pyw", line 132, in iter_logs
    with open_methods[file.suffix](file, 'rt', encoding='ansi', errors='replace', newline='') as f:
  File "/usr/lib/python3.10/gzip.py", line 66, in open
    return io.TextIOWrapper(binary_file, encoding, errors, newline)
LookupError: unknown encoding: ansi
```
It seems that ansi isn't actually supported in python (or so I heard) so I changed it to UTF-8 which made it work perfectly.

And then I added a bit of info in the README to tell linux users they could run it as seeing the exe might turn them away.
Feel free to take/leave/revert any of these changes.